### PR TITLE
feat: add serverless express setup and API routes

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,28 @@
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import serverlessExpress from '@vendia/serverless-express';
+
+import CvController from '../app/routes/CandidatesRouter.js';
+import vacanciesControllers from '../app/routes/VacanciesRouter.js';
+import applicationsController from '../app/routes/ApplicationsRouter.js';
+import candidatesController from '../app/routes/CandidatesRouter.js';
+import usersController from '../app/routes/UsersRouter.js';
+import candidateSharesController from '../app/routes/CandidateSharesRouter.js';
+import authController from '../app/routes/AuthRouter.js';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.use('/api/aicv', CvController);
+app.use('/api/vacancies', vacanciesControllers);
+app.use('/api/applications', applicationsController);
+app.use('/api/candidates', candidatesController);
+app.use('/api/users', usersController);
+app.use('/api/shares', candidateSharesController);
+app.use('/api/auth', authController);
+
+export default serverlessExpress({ app });

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "json-server": "^1.0.0-beta.3"
   },
   "dependencies": {
+    "@vendia/serverless-express": "^4.12.6",
     "argon2": "^0.44.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",


### PR DESCRIPTION
This pull request sets up the main Express application for the API and prepares it to run in a serverless environment. It introduces the core API routing structure, integrates essential middleware, and adds a dependency for serverless deployment.

API and serverless setup:

* Created the main Express app in `api/index.js`, added middleware (`cors`, `express.json`), and configured routing for candidates, vacancies, applications, users, shares, and authentication.
* Integrated `@vendia/serverless-express` for serverless deployment and added it as a dependency in `package.json`. [[1]](diffhunk://#diff-0cd6077e2a9b32718203a28a9a3c363aef0be6a1516e863b91fb0bc842133933R1-R28) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R21)