### PR TITLE
refactor: update API routes to remove '/api' prefix

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -17,12 +17,12 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-app.use('/api/aicv', CvController);
-app.use('/api/vacancies', vacanciesControllers);
-app.use('/api/applications', applicationsController);
-app.use('/api/candidates', candidatesController);
-app.use('/api/users', usersController);
-app.use('/api/shares', candidateSharesController);
-app.use('/api/auth', authController);
+app.use('/aicv', CvController);
+app.use('/vacancies', vacanciesControllers);
+app.use('/applications', applicationsController);
+app.use('/candidates', candidatesController);
+app.use('/users', usersController);
+app.use('/shares', candidateSharesController);
+app.use('/auth', authController);
 
 export default serverlessExpress({ app });


### PR DESCRIPTION
This pull request updates the API route prefixes in the `api/index.js` file to remove the `/api` segment from all endpoint paths. This change simplifies the URLs used to access the application's backend services.

Routing changes:

* Removed the `/api` prefix from all API endpoints, so routes like `/api/aicv` are now accessible at `/aicv`, `/api/vacancies` at `/vacancies`, and so on.