### PR TITLE
fix: prefix endpoitns

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -17,12 +17,12 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-app.use('/api/aicv', CvController);
-app.use('/api/vacancies', vacanciesControllers);
-app.use('/api/applications', applicationsController);
-app.use('/api/candidates', candidatesController);
-app.use('/api/users', usersController);
-app.use('/api/shares', candidateSharesController);
-app.use('/api/auth', authController);
+app.use('/aicv', CvController);
+app.use('/vacancies', vacanciesControllers);
+app.use('/applications', applicationsController);
+app.use('/candidates', candidatesController);
+app.use('/users', usersController);
+app.use('/shares', candidateSharesController);
+app.use('/auth', authController);
 
 export default serverlessExpress({ app });

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,28 @@
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import serverlessExpress from '@vendia/serverless-express';
+
+import CvController from '../app/routes/CandidatesRouter.js';
+import vacanciesControllers from '../app/routes/VacanciesRouter.js';
+import applicationsController from '../app/routes/ApplicationsRouter.js';
+import candidatesController from '../app/routes/CandidatesRouter.js';
+import usersController from '../app/routes/UsersRouter.js';
+import candidateSharesController from '../app/routes/CandidateSharesRouter.js';
+import authController from '../app/routes/AuthRouter.js';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.use('/api/aicv', CvController);
+app.use('/api/vacancies', vacanciesControllers);
+app.use('/api/applications', applicationsController);
+app.use('/api/candidates', candidatesController);
+app.use('/api/users', usersController);
+app.use('/api/shares', candidateSharesController);
+app.use('/api/auth', authController);
+
+export default serverlessExpress({ app });

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "json-server": "^1.0.0-beta.3"
   },
   "dependencies": {
+    "@vendia/serverless-express": "^4.12.6",
     "argon2": "^0.44.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",


### PR DESCRIPTION
This pull request updates the API route paths in `api/index.js` by removing the `/api` prefix from all endpoint registrations. This change simplifies the URLs that clients will use to access the application's API endpoints.

**API Route Changes:**

* Removed the `/api` prefix from all route registrations, so endpoints like `/api/aicv` are now accessible at `/aicv`, `/api/vacancies` at `/vacancies`, etc.